### PR TITLE
Initialize toast library

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ReactComponent, WidgetConfig, WidgetEditors, PropertySettings } from './src/components/component';
 import { connectWidget } from 'apptile-core';
+import { ToastProvider } from 'react-native-toast-notifications';
 
 const Connected = connectWidget(
   'plantdashboard',
@@ -12,5 +13,9 @@ const Connected = connectWidget(
 );
 
 export default function App() {
-  return <Connected model={{ get: () => {} }} />;
+  return (
+    <ToastProvider>
+      <Connected model={{ get: () => {} }} />
+    </ToastProvider>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "apptile-core": "^1.0.0",
     "react-redux": "^8.0.0",
     "redux": "^4.2.0",
-    "moment": "^2.29.0"
+    "moment": "^2.29.0",
+    "react-native-toast-notifications": "^3.3.2"
   }
 }

--- a/src/components/component.jsx
+++ b/src/components/component.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Image } from 'react-native';
+import { useToast } from 'react-native-toast-notifications';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { useApptileWindowDims, navigateToScreen, Icon } from 'apptile-core';
 import { SmartCareOverview } from './SmartCareOverview';
@@ -14,6 +15,7 @@ export function ReactComponent({ model }) {
   const id = model.get('id');
   const { width, height } = useApptileWindowDims();
   const dispatch = useDispatch();
+  const toast = useToast();
   
   // Get props from model
   const showQuickStats = model.get('showQuickStats') !== false; // default true


### PR DESCRIPTION
## Summary
- add `react-native-toast-notifications` dependency
- wrap root with `ToastProvider`
- use `useToast` in component

## Testing
- `npm install` *(fails: `apptile-core` missing)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688162ec78d48324b5d9c1e0ad4dc879