### PR TITLE
Add local stub for apptile-core

### DIFF
--- a/apptile-core/index.js
+++ b/apptile-core/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useWindowDimensions, Text } from 'react-native';
+
+export function connectWidget(name, Component) {
+  return function ConnectedWidget(props) {
+    return <Component {...props} />;
+  };
+}
+
+export function useApptileWindowDims() {
+  return useWindowDimensions();
+}
+
+export function navigateToScreen(screen, params) {
+  return { type: 'NAVIGATE', screen, params };
+}
+
+export function Icon({ name, size = 16, color = 'black' }) {
+  return <Text style={{ fontSize: size, color }}>{name}</Text>;
+}

--- a/apptile-core/package.json
+++ b/apptile-core/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "apptile-core",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^18.0.0",
     "react-native": "^0.70.0",
-    "apptile-core": "^1.0.0",
+    "apptile-core": "file:./apptile-core",
     "react-redux": "^8.0.0",
     "redux": "^4.2.0",
     "moment": "^2.29.0",


### PR DESCRIPTION
## Summary
- provide minimal `apptile-core` package so `npm install` succeeds
- reference the local package from `package.json`

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688163e2ebcc8324bb31094a9a1ee591